### PR TITLE
Followup cleanup for function qualification PR

### DIFF
--- a/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
+++ b/sql/api/src/main/scala/org/apache/spark/sql/errors/QueryParsingErrors.scala
@@ -674,6 +674,20 @@ private[sql] object QueryParsingErrors extends DataTypeErrorsBase {
     new ParseException(errorClass = "INVALID_SQL_SYNTAX.CREATE_TEMP_FUNC_WITH_IF_NOT_EXISTS", ctx)
   }
 
+  def invalidTempObjQualifierError(
+      objectType: String,
+      objectName: String,
+      qualifier: String,
+      ctx: ParserRuleContext): Throwable = {
+    new ParseException(
+      "INVALID_TEMP_OBJ_QUALIFIER",
+      Map(
+        "objectType" -> objectType,
+        "objectName" -> toSQLId(objectName),
+        "qualifier" -> toSQLId(qualifier)),
+      ctx)
+  }
+
   def unsupportedFunctionNameError(funcName: Seq[String], ctx: ParserRuleContext): Throwable = {
     new ParseException(
       errorClass = "INVALID_SQL_SYNTAX.MULTI_PART_NAME",

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
@@ -22,7 +22,6 @@ import scala.jdk.CollectionConverters._
 import org.apache.spark.SparkException
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, SqlScriptingContextManager}
-import org.apache.spark.sql.catalyst.catalog.SessionCatalog
 import org.apache.spark.sql.catalyst.expressions.AttributeReference
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
@@ -86,8 +85,29 @@ class ResolveCatalogs(val catalogManager: CatalogManager)
       assertValidSessionVariableNameParts(nameParts, resolved)
       d.copy(name = resolved)
 
+    case CreateFunction(UnresolvedIdentifier(nameParts, _), _, _, _, _)
+        if isSystemBuiltinName(nameParts) =>
+      throw QueryCompilationErrors.operationNotAllowedOnBuiltinFunctionError(
+        "CREATE", nameParts.last)
+
+    case CreateUserDefinedFunction(UnresolvedIdentifier(nameParts, _),
+        _, _, _, _, _, _, _, _, _, _, _)
+        if isSystemBuiltinName(nameParts) =>
+      throw QueryCompilationErrors.operationNotAllowedOnBuiltinFunctionError(
+        "CREATE", nameParts.last)
+
+    case DropFunction(UnresolvedIdentifier(nameParts, _), _)
+        if isSystemBuiltinName(nameParts) =>
+      throw QueryCompilationErrors.operationNotAllowedOnBuiltinFunctionError(
+        "DROP", nameParts.last)
+
     case d @ DropFunction(u @ UnresolvedIdentifier(nameParts, _), _) =>
       d.copy(child = resolveFunctionIdentifier(nameParts, u.origin))
+
+    case RefreshFunction(UnresolvedIdentifier(nameParts, _))
+        if isSystemBuiltinName(nameParts) =>
+      throw QueryCompilationErrors.operationNotAllowedOnBuiltinFunctionError(
+        "REFRESH", nameParts.last)
 
     case r @ RefreshFunction(u @ UnresolvedIdentifier(nameParts, _)) =>
       r.copy(child = resolveFunctionIdentifier(nameParts, u.origin))
@@ -135,11 +155,16 @@ class ResolveCatalogs(val catalogManager: CatalogManager)
     }
   }
 
+  private def isSystemBuiltinName(nameParts: Seq[String]): Boolean = {
+    nameParts.length == 3 &&
+      nameParts(0).equalsIgnoreCase(CatalogManager.SYSTEM_CATALOG_NAME) &&
+      nameParts(1).equalsIgnoreCase(CatalogManager.BUILTIN_NAMESPACE)
+  }
+
   /**
    * Resolves a function identifier, checking for builtin and temp functions first.
-   * Builtin and temp functions are only registered with unqualified names, but can be
-   * referenced with qualified names like builtin.abs, system.builtin.abs, session.func,
-   * or system.session.func.
+   * Only unqualified (1-part) names get special builtin/temp handling; multi-part names
+   * go through standard catalog resolution.
    */
   private def resolveFunctionIdentifier(
       nameParts: Seq[String],
@@ -157,18 +182,9 @@ class ResolveCatalogs(val catalogManager: CatalogManager)
         val CatalogAndIdentifier(catalog, ident) = nameParts
         ResolvedIdentifier(catalog, ident)
       }
-    } else FunctionResolution.sessionNamespaceKind(nameParts) match {
-      case Some(SessionCatalog.Builtin) | Some(SessionCatalog.Extension) =>
-        // Explicitly qualified as builtin or extension (extension stored as builtin)
-        val ident = Identifier.of(Array(CatalogManager.BUILTIN_NAMESPACE), nameParts.last)
-        ResolvedIdentifier(FakeSystemCatalog, ident)
-      case Some(SessionCatalog.Temp) =>
-        // Explicitly qualified as temp (e.g., session.func or system.session.func)
-        val ident = Identifier.of(Array(CatalogManager.SESSION_NAMESPACE), nameParts.last)
-        ResolvedIdentifier(FakeSystemCatalog, ident)
-      case None =>
-        val CatalogAndIdentifier(catalog, ident) = nameParts
-        ResolvedIdentifier(catalog, ident)
+    } else {
+      val CatalogAndIdentifier(catalog, ident) = nameParts
+      ResolvedIdentifier(catalog, ident)
     }
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/ResolverGuard.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/resolver/ResolverGuard.scala
@@ -388,20 +388,6 @@ class ResolverGuard(catalogManager: CatalogManager) extends SQLConfHelper {
     !shouldReject && unresolvedFunction.children.forall(checkExpression)
   }
 
-  /**
-   * Returns true if the name is unqualified or explicitly qualified as builtin
-   * (e.g. builtin.func, system.builtin.func).
-   *
-   * @note Reserved for future use (e.g. guard rules that treat builtin-qualified
-   *       names differently).
-   * @param nameParts the parts of the function name
-   * @return true if the name is unqualified, "builtin.func", or "system.builtin.func"
-   */
-  private def isBuiltinOrUnqualified(nameParts: Seq[String]): Boolean = {
-    nameParts.length == 1 ||
-      FunctionResolution.sessionNamespaceKind(nameParts).contains(SessionCatalog.Builtin)
-  }
-
   private def checkLiteral(literal: Literal) = true
 
   private def checkUnresolvedOrdinal(unresolvedOrdinal: UnresolvedOrdinal) = true

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/CatalogManager.scala
@@ -162,10 +162,5 @@ private[sql] object CatalogManager {
   val SESSION_CATALOG_NAME: String = "spark_catalog"
   val SYSTEM_CATALOG_NAME = "system"
   val SESSION_NAMESPACE = "session"
-  /**
-   * Used only for explicit qualification; extension functions are resolved via
-   * the builtin namespace in the default path.
-   */
-  val EXTENSION_NAMESPACE = "extension"
   val BUILTIN_NAMESPACE = "builtin"
 }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/LookupCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/connector/catalog/LookupCatalog.scala
@@ -123,11 +123,6 @@ private[sql] trait LookupCatalog extends Logging {
           val catalog = catalogManager.catalog(nameParts.head)
           val ident = nameParts.tail.asIdentifier
           if (CatalogV2Util.isSessionCatalog(catalog)) {
-            val ns = ident.namespace().toSeq
-            if (ns.nonEmpty && ns.last.equalsIgnoreCase(CatalogManager.BUILTIN_NAMESPACE)) {
-              throw QueryCompilationErrors.operationNotAllowedOnBuiltinNamespaceError(
-                "CREATE", "OBJECT", ident.name())
-            }
             // Reject only when namespace is empty (e.g. spark_catalog.t with no database).
             // Allow multi-part namespace for metadata tables (e.g. default.table.snapshots).
             if (ident.namespace().isEmpty) {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/errors/QueryCompilationErrors.scala
@@ -3104,18 +3104,6 @@ private[sql] object QueryCompilationErrors extends QueryErrorsBase with Compilat
         "objectName" -> toSQLId(objectName)))
   }
 
-  def invalidTempObjQualifierError(
-      objectType: String,
-      objectName: String,
-      qualifier: String): Throwable = {
-    new AnalysisException(
-      errorClass = "INVALID_TEMP_OBJ_QUALIFIER",
-      messageParameters = Map(
-        "objectType" -> objectType,
-        "objectName" -> toSQLId(objectName),
-        "qualifier" -> toSQLId(qualifier)))
-  }
-
   def cannotRefreshBuiltInFuncError(functionName: String, t: TreeNode[_]): Throwable = {
     new AnalysisException(
       errorClass = "_LEGACY_ERROR_TEMP_1256",

--- a/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectProtoSuite.scala
+++ b/sql/connect/server/src/test/scala/org/apache/spark/sql/connect/planner/SparkConnectProtoSuite.scala
@@ -121,10 +121,7 @@ class SparkConnectProtoSuite extends PlanTest with SparkConnectPlanTest {
     val connectPlan =
       connectTestRelation.select(callFunction(Seq("default", "hex"), Seq("id".protoAttr)))
 
-    // With function qualification support, this now throws AnalysisException
-    // (wrapped in SparkException) because the function cannot be resolved,
-    // rather than UnsupportedOperationException
-    assertThrows[org.apache.spark.SparkUnsupportedOperationException] {
+    assertThrows[UnsupportedOperationException] {
       analyzePlan(transform(connectPlan))
     }
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSessionExtensions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSessionExtensions.scala
@@ -365,33 +365,14 @@ class SparkSessionExtensions {
 
   private[sql] def registerFunctions(functionRegistry: FunctionRegistry) = {
     for ((name, expressionInfo, function) <- injectedFunctions) {
-      // Extension functions are treated as builtins - stored unqualified.
-      // This allows power users (Sedona, Delta, etc.) to overwrite existing builtins if needed.
-      // Extension functions cannot be shadowed by temporary/session functions in secure mode.
-      val identifier = if (name.database.isEmpty && name.catalog.isEmpty) {
-        // Unqualified extension - store as builtin (unqualified)
-        FunctionIdentifier(name.funcName)
-      } else {
-        // Already qualified - keep as-is (power user knows what they're doing)
-        name
-      }
-      functionRegistry.registerFunction(identifier, expressionInfo, function)
+      functionRegistry.registerFunction(name, expressionInfo, function)
     }
     functionRegistry
   }
 
   private[sql] def registerTableFunctions(tableFunctionRegistry: TableFunctionRegistry) = {
     for ((name, expressionInfo, function) <- injectedTableFunctions) {
-      // Extension table functions are treated as builtins - stored unqualified.
-      // This allows power users to overwrite existing builtin table functions if needed.
-      val identifier = if (name.database.isEmpty && name.catalog.isEmpty) {
-        // Unqualified extension - store as builtin (unqualified)
-        FunctionIdentifier(name.funcName)
-      } else {
-        // Already qualified - keep as-is (power user knows what they're doing)
-        name
-      }
-      tableFunctionRegistry.registerFunction(identifier, expressionInfo, function)
+      tableFunctionRegistry.registerFunction(name, expressionInfo, function)
     }
     tableFunctionRegistry
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveSessionCatalog.scala
@@ -574,26 +574,8 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
         throw QueryCompilationErrors.missingCatalogRefreshFunctionAbilityError(catalog)
       }
 
-    case CreateFunction(UnresolvedIdentifier(nameParts, _), _, _, _, _)
-        if nameParts.length >= 2 &&
-          nameParts(nameParts.length - 2).equalsIgnoreCase(CatalogManager.BUILTIN_NAMESPACE) =>
-      throw QueryCompilationErrors.operationNotAllowedOnBuiltinFunctionError(
-        "CREATE", nameParts.last)
-
-    case CreateFunction(
-        ResolvedIdentifier(catalog, ident), _, _, _, _)
-        if isSessionCatalog(catalog) &&
-          ident.namespace().length >= 1 &&
-          ident.namespace().last.equalsIgnoreCase(CatalogManager.BUILTIN_NAMESPACE) =>
-      throw QueryCompilationErrors.operationNotAllowedOnBuiltinFunctionError(
-        "CREATE", ident.name())
-
     case CreateFunction(
         ResolvedIdentifierInSessionCatalog(ident), className, resources, ifExists, replace) =>
-      if (ident.database.exists(_.equalsIgnoreCase(CatalogManager.BUILTIN_NAMESPACE))) {
-        throw QueryCompilationErrors.operationNotAllowedOnBuiltinFunctionError(
-          "CREATE", ident.table)
-      }
       CreateFunctionCommand(
         FunctionIdentifier(ident.table, ident.database, ident.catalog),
         className,
@@ -606,26 +588,7 @@ class ResolveSessionCatalog(val catalogManager: CatalogManager)
       throw QueryCompilationErrors.missingCatalogCreateFunctionAbilityError(catalog)
 
     case c @ CreateUserDefinedFunction(
-        UnresolvedIdentifier(nameParts, _), _, _, _, _, _, _, _, _, _, _, _)
-        if nameParts.length >= 2 &&
-          nameParts(nameParts.length - 2).equalsIgnoreCase(CatalogManager.BUILTIN_NAMESPACE) =>
-      throw QueryCompilationErrors.operationNotAllowedOnBuiltinFunctionError(
-        "CREATE", nameParts.last)
-
-    case c @ CreateUserDefinedFunction(
-        ResolvedIdentifier(catalog, ident), _, _, _, _, _, _, _, _, _, _, _)
-        if isSessionCatalog(catalog) &&
-          ident.namespace().length >= 1 &&
-          ident.namespace().last.equalsIgnoreCase(CatalogManager.BUILTIN_NAMESPACE) =>
-      throw QueryCompilationErrors.operationNotAllowedOnBuiltinFunctionError(
-        "CREATE", ident.name())
-
-    case c @ CreateUserDefinedFunction(
         ResolvedIdentifierInSessionCatalog(ident), _, _, _, _, _, _, _, _, _, _, _) =>
-      if (ident.database.exists(_.equalsIgnoreCase(CatalogManager.BUILTIN_NAMESPACE))) {
-        throw QueryCompilationErrors.operationNotAllowedOnBuiltinFunctionError(
-          "CREATE", ident.table)
-      }
       CreateUserDefinedFunctionCommand(
         FunctionIdentifier(ident.table, ident.database, ident.catalog),
         c.inputParamText,

--- a/sql/core/src/main/scala/org/apache/spark/sql/classic/Catalog.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/classic/Catalog.scala
@@ -365,13 +365,9 @@ class Catalog(sparkSession: SparkSession) extends catalog.Catalog {
           isTemporary = true)
 
       case _ =>
-        val isSessionCatalog = currentCatalog() == CatalogManager.SESSION_CATALOG_NAME
-        val catalogPath: Seq[String] = if (isSessionCatalog) {
+        val catalogPath =
           (Seq(currentCatalog()) ++
             sparkSession.sessionState.catalogManager.currentNamespace).toSeq
-        } else {
-          Seq.empty[String]
-        }
         val searchPath = sparkSession.sessionState.conf.resolutionSearchPath(catalogPath)
         throw QueryCompilationErrors.unresolvedRoutineError(
           ident,

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkSqlParser.scala
@@ -200,8 +200,8 @@ class SparkSqlAstBuilder extends AstBuilder {
           // Otherwise it's an invalid qualifier (e.g., database name)
           val funcName = functionIdentifier.last
           val qualifier = functionIdentifier.head
-          throw QueryCompilationErrors.invalidTempObjQualifierError(
-            "FUNCTION", funcName, qualifier)
+          throw QueryParsingErrors.invalidTempObjQualifierError(
+            "FUNCTION", funcName, qualifier, ctx)
         }
       case 3 =>
         // Check if it's system.session.funcName
@@ -212,15 +212,15 @@ class SparkSqlAstBuilder extends AstBuilder {
           // Invalid three-part qualifier
           val funcName = functionIdentifier.last
           val qualifier = functionIdentifier.init.mkString(".")
-          throw QueryCompilationErrors.invalidTempObjQualifierError(
-            "FUNCTION", funcName, qualifier)
+          throw QueryParsingErrors.invalidTempObjQualifierError(
+            "FUNCTION", funcName, qualifier, ctx)
         }
       case _ =>
         // More than 3 parts - invalid
         val funcName = functionIdentifier.last
         val qualifier = functionIdentifier.init.mkString(".")
-        throw QueryCompilationErrors.invalidTempObjQualifierError(
-          "FUNCTION", funcName, qualifier)
+        throw QueryParsingErrors.invalidTempObjQualifierError(
+          "FUNCTION", funcName, qualifier, ctx)
     }
   }
 

--- a/sql/core/src/test/scala/org/apache/spark/sql/FunctionQualificationSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/FunctionQualificationSuite.scala
@@ -27,9 +27,6 @@ import org.apache.spark.sql.types.IntegerType
  * Tests builtin/temp/persistent function name disambiguation with qualified names.
  * This tests the system.builtin, system.session, and system.extension namespaces.
  *
- * Includes tests from:
- * 1. function-qualification.sql golden file (SQL-accessible functions)
- * 2. Extension function tests (programmatic registration via SparkSessionExtensions)
  */
 class FunctionQualificationSuite extends QueryTest with SharedSparkSession {
 
@@ -361,9 +358,10 @@ class FunctionQualificationSuite extends QueryTest with SharedSparkSession {
   }
 
   test("SECTION 7a: Error Cases - cannot create temp function with builtin namespace") {
+    val sqlText = "CREATE TEMPORARY FUNCTION system.builtin.my_builtin() RETURNS INT RETURN 1"
     checkError(
       exception = intercept[ParseException] {
-        sql("CREATE TEMPORARY FUNCTION system.builtin.my_builtin() RETURNS INT RETURN 1")
+        sql(sqlText)
       },
       condition = "INVALID_TEMP_OBJ_QUALIFIER",
       sqlState = "42602",
@@ -371,14 +369,20 @@ class FunctionQualificationSuite extends QueryTest with SharedSparkSession {
         "objectName" -> "`my_builtin`",
         "objectType" -> "FUNCTION",
         "qualifier" -> "`system`.`builtin`"
+      ),
+      context = ExpectedContext(
+        fragment = sqlText,
+        start = 0,
+        stop = sqlText.length - 1
       )
     )
   }
 
   test("SECTION 7b: Error Cases - cannot create temp function with invalid database") {
+    val sqlText = "CREATE TEMPORARY FUNCTION mydb.my_func() RETURNS INT RETURN 1"
     checkError(
       exception = intercept[ParseException] {
-        sql("CREATE TEMPORARY FUNCTION mydb.my_func() RETURNS INT RETURN 1")
+        sql(sqlText)
       },
       condition = "INVALID_TEMP_OBJ_QUALIFIER",
       sqlState = "42602",
@@ -386,6 +390,11 @@ class FunctionQualificationSuite extends QueryTest with SharedSparkSession {
         "objectName" -> "`my_func`",
         "objectType" -> "FUNCTION",
         "qualifier" -> "`mydb`"
+      ),
+      context = ExpectedContext(
+        fragment = sqlText,
+        start = 0,
+        stop = sqlText.length - 1
       )
     )
   }
@@ -418,6 +427,18 @@ class FunctionQualificationSuite extends QueryTest with SharedSparkSession {
         "objectName" -> "`my_func`"
       )
     )
+  }
+
+  test("SECTION 7d2: 2-part names with 'builtin' schema are not system namespace references") {
+    // `builtin.name` in DDL should be treated as `current_catalog.builtin.name`,
+    // not as a reference to the system builtin namespace.
+    withDatabase("builtin") {
+      sql("CREATE DATABASE IF NOT EXISTS builtin")
+      sql("CREATE FUNCTION builtin.my_test_func AS 'test.org.apache.spark.sql.MyDoubleAvg'")
+      // REFRESH should resolve against the schema, not the system builtin namespace
+      sql("REFRESH FUNCTION builtin.my_test_func")
+      sql("DROP FUNCTION builtin.my_test_func")
+    }
   }
 
   // COMMENT ON FUNCTION is not yet supported in the parser; when added, we should reject
@@ -557,38 +578,34 @@ class FunctionQualificationSuite extends QueryTest with SharedSparkSession {
     checkAnswer(sql("SELECT System.Builtin.Count(*) FROM VALUES (1), (2), (3) AS t(a)"), Row(3))
   }
 
-  test("SECTION 10b: COUNT(*) - invalid qualified names rejected") {
-    // Invalid qualifier "foo.bar" should not be treated as count
+  test("SECTION 10b: COUNT(*) - non-builtin qualified names") {
+    // spark_catalog.default.count is not recognized as the builtin count,
+    // so the COUNT(*)->COUNT(1) rewrite does not apply.
     checkError(
       exception = intercept[AnalysisException] {
-        sql("SELECT foo.bar.count(*) FROM VALUES (1), (2), (3) AS t(a)")
+        sql("SELECT spark_catalog.default.count(*) FROM VALUES (1), (2), (3) AS t(a)")
       },
       condition = "UNRESOLVED_ROUTINE",
       parameters = Map(
-        "routineName" -> "`foo`.`bar`.`count`",
+        "routineName" -> "`spark_catalog`.`default`.`count`",
         "searchPath" -> "[`system`.`builtin`, `system`.`session`, `spark_catalog`.`default`]"
       ),
       context = ExpectedContext(
-        fragment = "foo.bar.count(*)",
+        fragment = "spark_catalog.default.count(*)",
         start = 7,
-        stop = 22
+        stop = 36
       )
     )
 
-    // Invalid qualifier "catalog.db" should not be treated as count
+    // 2-part name spark_catalog.count is rejected as invalid (empty namespace on session catalog)
     checkError(
       exception = intercept[AnalysisException] {
-        sql("SELECT catalog.db.count(*) FROM VALUES (1), (2), (3) AS t(a)")
+        sql("SELECT spark_catalog.count(*) FROM VALUES (1), (2), (3) AS t(a)")
       },
-      condition = "UNRESOLVED_ROUTINE",
+      condition = "REQUIRES_SINGLE_PART_NAMESPACE",
       parameters = Map(
-        "routineName" -> "`catalog`.`db`.`count`",
-        "searchPath" -> "[`system`.`builtin`, `system`.`session`, `spark_catalog`.`default`]"
-      ),
-      context = ExpectedContext(
-        fragment = "catalog.db.count(*)",
-        start = 7,
-        stop = 25
+        "sessionCatalog" -> "spark_catalog",
+        "identifier" -> "`count`"
       )
     )
   }
@@ -761,7 +778,7 @@ class FunctionQualificationSuite extends QueryTest with SharedSparkSession {
     checkAnswer(sql("SELECT test_ext_func()"), Row(9999))
   }
 
-  test("SECTION 12b: Extension - resolution order: extension > builtin > session") {
+  test("SECTION 12b: Extension - session function resolves when no builtin conflict") {
     // Test the critical security property: extension comes before builtin before session
     sql("CREATE TEMPORARY FUNCTION session_func() RETURNS INT RETURN 1111")
 
@@ -964,21 +981,17 @@ class FunctionQualificationSuite extends QueryTest with SharedSparkSession {
     }
   }
 
-  test("SECTION 13g: Multi-part name with invalid namespace yields UNRESOLVED_ROUTINE " +
-    "with search path") {
-    // A 3-part name like x.y.func triggers REQUIRES_SINGLE_PART_NAMESPACE in the session catalog;
-    // LookupFunctions converts it to unresolved routine error with the configured search path.
+  test("SECTION 13g: Multi-part name with invalid namespace yields " +
+    "REQUIRES_SINGLE_PART_NAMESPACE") {
+    // A 3-part name like x.y.func where x is not a known catalog falls back to the session
+    // catalog with a multi-part namespace, which the session catalog does not support.
     checkError(
       exception = intercept[AnalysisException] { sql("SELECT x.y.no_such_xyz()") },
-      condition = "UNRESOLVED_ROUTINE",
+      condition = "REQUIRES_SINGLE_PART_NAMESPACE",
       parameters = Map(
-        "routineName" -> "`x`.`y`.`no_such_xyz`",
-        "searchPath" -> "[`system`.`builtin`, `system`.`session`, `spark_catalog`.`default`]"
-      ),
-      context = ExpectedContext(
-        fragment = "x.y.no_such_xyz()",
-        start = 7,
-        stop = 23))
+        "sessionCatalog" -> "spark_catalog",
+        "identifier" -> "`x`.`y`.`no_such_xyz`"
+      ))
   }
 
   test("SECTION 13h: Legacy mode - default behavior allows registration but builtin wins") {

--- a/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/errors/QueryParsingErrorsSuite.scala
@@ -313,7 +313,11 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession with SQL
       parameters = Map(
         "objectType" -> "FUNCTION",
         "objectName" -> "`func`",
-        "qualifier" -> "`ns`.`db`"))
+        "qualifier" -> "`ns`.`db`"),
+      context = ExpectedContext(
+        fragment = sqlText,
+        start = 0,
+        stop = sqlText.length - 1))
   }
 
   test("INVALID_TEMP_OBJ_QUALIFIER: " +
@@ -330,7 +334,11 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession with SQL
       parameters = Map(
         "objectType" -> "FUNCTION",
         "objectName" -> "`func`",
-        "qualifier" -> "`db`"))
+        "qualifier" -> "`db`"),
+      context = ExpectedContext(
+        fragment = sqlText,
+        start = 0,
+        stop = sqlText.length - 1))
   }
 
   test("INVALID_TEMP_OBJ_QUALIFIER: Drop temporary function with invalid qualification") {
@@ -342,7 +350,11 @@ class QueryParsingErrorsSuite extends QueryTest with SharedSparkSession with SQL
       parameters = Map(
         "objectType" -> "FUNCTION",
         "objectName" -> "`func`",
-        "qualifier" -> "`db`"))
+        "qualifier" -> "`db`"),
+      context = ExpectedContext(
+        fragment = sqlText,
+        start = 0,
+        stop = sqlText.length - 1))
   }
 
   test("DUPLICATE_KEY: Found duplicate partition keys") {


### PR DESCRIPTION
## Summary

Followup cleanup for the function qualification PR (apache/spark#53570). These changes simplify the implementation, remove dead code, and fix test bugs.

### Dead code / simplification
- Remove `Extension` as a separate `SessionFunctionKind`; extension functions are builtins and don't need their own namespace kind
- Remove `EXTENSION_NAMESPACE`, `extensionFunctionIdentifier`, `isExtensionFunctionIdentifier`, `isExtensionNamespace`, `maybeExtensionFunctionName` and all related branches
- Remove catch-rethrow blocks for `REQUIRES_SINGLE_PART_NAMESPACE` in `Analyzer.LookupFunctions` and `FunctionResolution.resolveQualifiedFunction` — let the error propagate naturally, same as table/view identifiers
- Simplify `lookupFunctionType`: the `sessionNamespaceKind` match had all branches doing the same thing; replaced with a single `if`
- Simplify `LookupFunctions` quick-check: two identical branches (`nameParts.size == 1` and `sessionNamespaceKind.isDefined`) merged into one condition
- Simplify `namespaceToIdentifier`: replaced `FunctionIdentifier(name, namespace.database, namespace.catalog)` with `namespace.copy(funcName = name)`
- Extract `currentCatalogPath` helper in `FunctionResolution` to remove 3 copies of the same `AnalysisContext.get.catalogAndNamespace` pattern
- Revert no-op `FunctionIdentifier` normalization in `SparkSessionExtensions.registerFunctions/registerTableFunctions`
- Remove hardcoded builtin namespace check in `LookupCatalog.CatalogAndIdentifier` extractor (it's general-purpose, not CREATE-specific)
- Remove dead `QueryCompilationErrors.invalidTempObjQualifierError` (moved to `QueryParsingErrors`)
- Remove redundant `UnresolvedIdentifier` pattern matches for `CreateFunction`/`CreateUserDefinedFunction` in `ResolveSessionCatalog` (the `ResolvedIdentifier` cases already handle these after resolution)

### Bug fixes
- Make `INVALID_TEMP_OBJ_QUALIFIER` a `ParseException` instead of `AnalysisException` — this error is thrown during parsing in `extractTempFunctionName`, so it should be a parse error with proper source location context. Moved the error factory from `QueryCompilationErrors` to `QueryParsingErrors`.
- Fix `DropFunctionCommand` to also validate catalog name (e.g. `DROP TEMPORARY FUNCTION bad_catalog.session.func`)
- Fix `Catalog.scala` to always include current catalog path in search path for `UNRESOLVED_ROUTINE` errors
- Fix `ResolveCatalogs.resolveFunctionIdentifier` — revert to base behavior (only 1-part names get special builtin/temp handling). The PR's change to also handle 2-part names like `builtin.name` and `session.name` was a breaking change: these should be treated as `current_catalog.schema.func`, not as system namespace references. Only the fully qualified 3-part `system.builtin.name` should be rejected for DDL.
- Add early `isSystemBuiltinName` checks in `ResolveCatalogs` for CREATE/DROP/REFRESH FUNCTION with `system.builtin.name` — these are caught before resolution and produce a clear `FORBIDDEN_OPERATION` error.
- Revert `SparkConnectProtoSuite` exception type change (`SparkUnsupportedOperationException` back to `UnsupportedOperationException`) — the actual thrown type was unchanged, the PR just unnecessarily tightened the assertion.

### Style / comments
- Rename `isQualifiedWithNamespace` → `isQualifiedWithSystemNamespace` for clarity
- Use consistent `.quoted` formatting for search path in `UNRESOLVED_ROUTINE` errors (was `.map(_.map(quoteIfNeeded).mkString("."))`)
- Fix stale comments referencing "extension" as a separate namespace kind
- Fix `lookupFunctionType` doc that incorrectly claimed "does not throw errors"
- Fix indentation in `SessionCatalog` (`isRegisteredFunction`, `loadPersistentScalarFunction`)
- Update test names and comments in `FunctionQualificationSuite` (SECTION 10b, 12b, 13g)

### Test coverage
- Add `SECTION 7d2` test: proves 2-part names like `builtin.my_test_func` are treated as regular schema references in DDL (CREATE, REFRESH, DROP all work against a real `builtin` schema)

## Test plan
- [x] `FunctionQualificationSuite` — all 54 tests pass
- [x] `QueryParsingErrorsSuite` — all 45 tests pass
- [ ] Full CI