### PR TITLE
Simplify function registry: enforce 3-part keys, add BuiltinRegistryMixin

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionRegistry.scala
@@ -210,26 +210,15 @@ trait SimpleFunctionRegistryBase[T] extends FunctionRegistryBase[T] with Logging
   protected val functionBuilders =
     new mutable.HashMap[FunctionIdentifier, (ExpressionInfo, FunctionBuilder)]
 
-  // Function name resolution is case-insensitive; database and catalog are preserved so
-  // system.session.foo and spark_catalog.session.foo do not collide. Unqualified (1-part)
-  // lookups resolve to the builtin 3-part key so that callers using FunctionIdentifier("time")
-  // find functions registered as system.builtin.time. A 2-part name with database=session
-  // and no catalog resolves to the temp 3-part key.
-  private def normalizeFuncName(name: FunctionIdentifier): FunctionIdentifier = {
-    if (name.database.isEmpty && name.catalog.isEmpty) {
-      FunctionRegistry.builtinFunctionIdentifier(name.funcName)
-    } else if (name.database.exists(_.equalsIgnoreCase(CatalogManager.SESSION_NAMESPACE)) &&
-        name.catalog.isEmpty) {
-      new FunctionIdentifier(
-        name.funcName.toLowerCase(Locale.ROOT),
-        Some(CatalogManager.SESSION_NAMESPACE),
-        Some(CatalogManager.SYSTEM_CATALOG_NAME))
-    } else {
-      new FunctionIdentifier(
-        name.funcName.toLowerCase(Locale.ROOT),
-        name.database,
-        name.catalog)
-    }
+  // All function identifiers must be fully qualified (3-part: catalog.database.funcName).
+  // Normalization lowercases all parts for case-insensitive lookup.
+  protected def normalizeFuncName(name: FunctionIdentifier): FunctionIdentifier = {
+    assert(name.database.isDefined && name.catalog.isDefined,
+      s"Function identifier must be fully qualified (3-part): $name")
+    new FunctionIdentifier(
+      name.funcName.toLowerCase(Locale.ROOT),
+      name.database.map(_.toLowerCase(Locale.ROOT)),
+      name.catalog.map(_.toLowerCase(Locale.ROOT)))
   }
 
   override def registerFunction(
@@ -333,6 +322,16 @@ class SimpleFunctionRegistry
     }
     registry
   }
+}
+
+/**
+ * A mixin for builtin-only registries that accepts any identifier and normalizes
+ * it to the builtin 3-part key (system.builtin.funcName). This allows callers to
+ * look up builtins by simple name without constructing a fully qualified identifier.
+ */
+trait BuiltinRegistryMixin[T] extends SimpleFunctionRegistryBase[T] {
+  override protected def normalizeFuncName(name: FunctionIdentifier): FunctionIdentifier =
+    super.normalizeFuncName(FunctionRegistry.builtinFunctionIdentifier(name.funcName))
 }
 
 object EmptyFunctionRegistry
@@ -1009,11 +1008,12 @@ object FunctionRegistry {
     expression[ToProtobuf]("to_protobuf")
   )
 
+  // BuiltinRegistryMixin normalizes any name to the builtin 3-part key (system.builtin.name).
   val builtin: SimpleFunctionRegistry = {
-    val fr = new SimpleFunctionRegistry
+    val fr = new SimpleFunctionRegistry with BuiltinRegistryMixin[Expression]
     expressions.foreach {
       case (name, (info, builder)) =>
-        fr.internalRegisterFunction(builtinFunctionIdentifier(name), info, builder)
+        fr.registerFunction(FunctionIdentifier(name), info, builder)
     }
     fr
   }
@@ -1021,7 +1021,8 @@ object FunctionRegistry {
   val functionSet: Set[FunctionIdentifier] = builtin.listFunction().toSet
 
   /** Registry for internal functions used by Connect and the Column API. */
-  private[sql] val internal: SimpleFunctionRegistry = new SimpleFunctionRegistry
+  private[sql] val internal: SimpleFunctionRegistry =
+    new SimpleFunctionRegistry with BuiltinRegistryMixin[Expression]
 
   private[spark] def registerInternalExpression[T <: Expression : ClassTag](
       name: String,
@@ -1036,9 +1037,8 @@ object FunctionRegistry {
     } else {
       builder
     }
-    // Internal functions are registered with the builtin identifier so that unqualified
-    // lookups, which normalize to system.builtin.name, find them.
-    internal.internalRegisterFunction(builtinFunctionIdentifier(name), info, newBuilder)
+    // BuiltinRegistryMixin normalizes to the builtin 3-part key (system.builtin.name).
+    internal.registerFunction(FunctionIdentifier(name), info, newBuilder)
   }
 
   registerInternalExpression[Product]("product")
@@ -1309,11 +1309,12 @@ object TableFunctionRegistry {
     PythonWorkerLogs.functionBuilder
   )
 
+  // BuiltinRegistryMixin normalizes any name to the builtin 3-part key (system.builtin.name).
   val builtin: SimpleTableFunctionRegistry = {
-    val fr = new SimpleTableFunctionRegistry
+    val fr = new SimpleTableFunctionRegistry with BuiltinRegistryMixin[LogicalPlan]
     logicalPlans.foreach {
       case (name, (info, builder)) =>
-        fr.internalRegisterFunction(FunctionRegistry.builtinFunctionIdentifier(name), info, builder)
+        fr.registerFunction(FunctionIdentifier(name), info, builder)
     }
     fr
   }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionResolution.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/FunctionResolution.scala
@@ -81,45 +81,35 @@ class FunctionResolution(
       nameParts.head.equalsIgnoreCase(CatalogManager.SYSTEM_CATALOG_NAME)
 
   /**
-   * Produces the ordered list of candidate names for resolution.
-   * Candidates are normally 3-part (catalog.database.function), assuming search path
-   * entries are catalog.database (2-part). A 2-part candidate is returned when a
-   * V2 catalog has no default namespace (handled by downstream expandIdentifier).
+   * Produces the ordered list of candidate names for resolution. Expansion happens in two cases:
    *
-   * @param nameParts The function name parts.
-   * @return A sequence of candidate names (usually 3-part) to attempt resolution with.
+   * 1. Single-part names: expanded via the search path, where each search path entry is
+   *    fully qualified so appending the name produces fully qualified candidates.
+   * 2. `builtin.name` or `session.name`: prepending `system` creates a fully qualified
+   *    system catalog candidate. The original 2-part name is also kept as a persistent
+   *    catalog candidate (qualified downstream). Order is controlled by
+   *    the `persistentCatalogFirst` config.
+   *
+   * All other multi-part names are returned as-is for downstream resolution.
    */
   private def resolutionCandidates(nameParts: Seq[String]): Seq[Seq[String]] = {
-    def ensureThreePart(parts: Seq[String]): Seq[String] =
-      if (parts.length == 3) parts
-      else if (parts.length == 2) currentCatalogPath.head +: parts
-      else parts  // Safety fallback; valid paths yield 2 or 3 parts before this point.
-
-    val n = nameParts.length
-    if (n == 1) {
-      // Search path entries are 2-part (catalog.database), so path ++ nameParts is always 3-part.
+    if (nameParts.size == 1) {
       val searchPath = SQLConf.get.resolutionSearchPath(currentCatalogPath)
       searchPath.map(_ ++ nameParts)
-    } else if (n == 2 && FunctionResolution.sessionNamespaceKind(nameParts).isDefined) {
-      // Partially qualified builtin/session: produce both candidates as 3-part
-      // (catalog.database.func).
+    } else if (nameParts.size == 2 &&
+        FunctionResolution.sessionNamespaceKind(nameParts).isDefined) {
       val systemCandidate = CatalogManager.SYSTEM_CATALOG_NAME +: nameParts
-      val persistentCandidate = currentCatalogPath.head +: nameParts
       if (SQLConf.get.prioritizeSystemCatalog) {
-        Seq(systemCandidate, persistentCandidate)
+        Seq(systemCandidate, nameParts)
       } else {
-        Seq(persistentCandidate, systemCandidate)
+        Seq(nameParts, systemCandidate)
       }
-    } else if (n == 2) {
-      // 2-part catalog.func: pass through for expandIdentifier (V2 catalog, no default namespace).
-      Seq(nameParts)
     } else {
-      // 3-part or other: use as-is or prepend current catalog to form 3-part.
-      Seq(ensureThreePart(nameParts))
+      Seq(nameParts)
     }
   }
 
-  private def resolveQualifiedFunction(
+  private def resolveFunctionCandidate(
       nameParts: Seq[String],
       unresolvedFunc: UnresolvedFunction): Option[Expression] = {
     if (isSystemCatalogQualified(nameParts)) {
@@ -163,11 +153,10 @@ class FunctionResolution(
     withPosition(unresolvedFunc) {
       // Internal functions resolve via the internal registry when the parser marks them as
       // internal; they are not resolved via the search path.
-      if (unresolvedFunc.isInternal && unresolvedFunc.nameParts.length == 1) {
-        val funcIdentifier = FunctionIdentifier(unresolvedFunc.nameParts.head)
+      if (unresolvedFunc.isInternal && unresolvedFunc.nameParts.size == 1) {
         try {
           val func = FunctionRegistry.internal.lookupFunction(
-            funcIdentifier, unresolvedFunc.arguments)
+            FunctionIdentifier(unresolvedFunc.nameParts.head), unresolvedFunc.arguments)
           return validateFunction(func, unresolvedFunc.arguments.length, unresolvedFunc)
         } catch {
           case _: NoSuchFunctionException =>
@@ -180,7 +169,7 @@ class FunctionResolution(
 
       val candidates = resolutionCandidates(unresolvedFunc.nameParts)
       for (nameParts <- candidates) {
-        resolveQualifiedFunction(nameParts, unresolvedFunc) match {
+        resolveFunctionCandidate(nameParts, unresolvedFunc) match {
           case Some(expr) => return expr
           case None =>
         }
@@ -191,7 +180,7 @@ class FunctionResolution(
     }
   }
 
-  private def resolveQualifiedTableFunction(
+  private def resolveTableFunctionCandidate(
       nameParts: Seq[String],
       arguments: Seq[Expression]): Option[LogicalPlan] = {
     if (isSystemCatalogQualified(nameParts)) {
@@ -250,7 +239,7 @@ class FunctionResolution(
       arguments: Seq[Expression]): Option[LogicalPlan] = {
     val candidates = resolutionCandidates(nameParts)
     for (nameParts <- candidates) {
-      resolveQualifiedTableFunction(nameParts, arguments) match {
+      resolveTableFunctionCandidate(nameParts, arguments) match {
         case Some(plan) => return Some(plan)
         case None =>
       }

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/analysis/ResolveCatalogs.scala
@@ -168,12 +168,11 @@ class ResolveCatalogs(val catalogManager: CatalogManager)
       nameParts: Seq[String],
       origin: Origin): ResolvedIdentifier = CurrentOrigin.withOrigin(origin) {
     if (nameParts.length == 1) {
-      val funcName = FunctionIdentifier(nameParts.head)
       val sessionCatalog = catalogManager.v1SessionCatalog
-      if (sessionCatalog.isBuiltinFunction(funcName)) {
+      if (sessionCatalog.isBuiltinFunction(nameParts.head)) {
         val ident = Identifier.of(Array(CatalogManager.BUILTIN_NAMESPACE), nameParts.head)
         ResolvedIdentifier(FakeSystemCatalog, ident)
-      } else if (sessionCatalog.isTemporaryFunction(funcName)) {
+      } else if (sessionCatalog.isTemporaryFunction(FunctionIdentifier(nameParts.head))) {
         val ident = Identifier.of(Array(CatalogManager.SESSION_NAMESPACE), nameParts.head)
         ResolvedIdentifier(FakeSystemCatalog, ident)
       } else {

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/catalog/SessionCatalog.scala
@@ -93,30 +93,19 @@ class SessionCatalog(
   import CatalogTypes.TablePartitionSpec
 
   /**
-   * Database qualifier used to store temporary functions in the function registry.
-   * Temporary functions use composite keys to coexist with builtin functions of the same name.
-   * Storage convention (see namespaceToIdentifier): builtins are stored as
-   * FunctionIdentifier(name, Some("builtin"), Some("system")); temp functions as
-   * FunctionIdentifier(name, Some("session"), Some("system")).
-   */
-  private val TEMP_FUNCTION_DB = CatalogManager.SESSION_NAMESPACE
-
-  /**
-   * Creates a FunctionIdentifier for a temporary function with the TEMP_FUNCTION_DB database
-   * qualifier. This enables temporary functions to coexist with builtin functions of the same name.
+   * Creates a FunctionIdentifier for a temporary function using SESSION_NAMESPACE_TEMPLATE.
+   * Temporary functions are stored with the session namespace (system.session) to coexist
+   * with builtin functions of the same name.
    */
   private def tempFunctionIdentifier(name: String): FunctionIdentifier =
-    FunctionIdentifier(
-      format(name),
-      Some(TEMP_FUNCTION_DB),
-      Some(CatalogManager.SYSTEM_CATALOG_NAME))
+    SESSION_NAMESPACE_TEMPLATE.copy(funcName = name)
 
   /**
-   * Checks if a FunctionIdentifier represents a temporary function by checking for the
-   * TEMP_FUNCTION_DB database qualifier.
+   * Checks if a FunctionIdentifier represents a temporary function by comparing
+   * its namespace (catalog + database) against SESSION_NAMESPACE_TEMPLATE.
    */
   private def isTempFunctionIdentifier(identifier: FunctionIdentifier): Boolean =
-    identifier.database.contains(TEMP_FUNCTION_DB)
+    identifier.copy(funcName = "") == SESSION_NAMESPACE_TEMPLATE
 
   // --------------------------------
   // | PATH-Based Resolution        |
@@ -176,25 +165,7 @@ class SessionCatalog(
     }
   }
 
-  /**
-   * Maps a namespace template to an actual storage identifier for a specific function.
-   *
-   * Storage conventions:
-   * - Builtin functions: FunctionIdentifier(name, Some("builtin"), Some("system"))
-   * - Temp functions: FunctionIdentifier(name, Some("session"), Some("system"))
-   * - Other: FunctionIdentifier(name, namespace.database, namespace.catalog)
-   */
-  private def namespaceToIdentifier(
-      namespace: FunctionIdentifier,
-      name: String): FunctionIdentifier = {
-    namespace.database match {
-      case Some(CatalogManager.BUILTIN_NAMESPACE) =>
-        FunctionRegistry.builtinFunctionIdentifier(name)
 
-      case _ =>
-        namespace.copy(funcName = name)
-    }
-  }
 
   /**
    * Checks if a namespace represents temporary functions.
@@ -217,7 +188,7 @@ class SessionCatalog(
       name: String,
       registry: FunctionRegistryBase[T]): Option[ExpressionInfo] = {
 
-    val identifier = namespaceToIdentifier(namespace, name)
+    val identifier = namespace.copy(funcName = name)
     val result = registry.lookupFunction(identifier)
 
     // Apply view context filtering for temp functions
@@ -244,7 +215,7 @@ class SessionCatalog(
       arguments: Seq[Expression],
       registry: FunctionRegistryBase[T]): Option[T] = {
 
-    val identifier = namespaceToIdentifier(namespace, name)
+    val identifier = namespace.copy(funcName = name)
 
     if (!registry.functionExists(identifier)) {
       None
@@ -2118,10 +2089,10 @@ class SessionCatalog(
     val func = funcDefinition.identifier
 
     // Determine the key to use for registration:
-    // - Temporary functions (unqualified): use composite key with TEMP_FUNCTION_DB database
+    // - Temporary functions (unqualified): use composite key with session namespace database
     // - Persistent functions (qualified): keep qualification to avoid conflicts
     val identToRegister = if (func.database.isEmpty) {
-      // Temporary function: use TEMP_FUNCTION_DB.funcName
+      // Temporary function: use session namespace.funcName
       tempFunctionIdentifier(func.funcName)
     } else {
       // Persistent function: keep original qualified identifier
@@ -2240,7 +2211,7 @@ class SessionCatalog(
     val isTemporary = function.name.database.isEmpty
 
     if (isTemporary) {
-      // Use FunctionIdentifier with TEMP_FUNCTION_DB for temporary functions
+      // Use FunctionIdentifier with session namespace for temporary functions
       val tempIdentifier = tempFunctionIdentifier(function.name.funcName)
 
       // Security check: When legacy mode is enabled, block SQL-created temporary functions
@@ -2291,7 +2262,7 @@ class SessionCatalog(
    * or [[TableFunctionRegistry]]. Return true if function exists.
    */
   def unregisterFunction(name: FunctionIdentifier): Boolean = {
-    // If it's an unqualified name, it's a temp function stored with TEMP_FUNCTION_DB database
+    // If it's an unqualified name, it's a temp function stored with session namespace database
     val tempIdent = if (name.database.isEmpty) tempFunctionIdentifier(name.funcName) else name
     functionRegistry.dropFunction(tempIdent) || tableFunctionRegistry.dropFunction(tempIdent)
   }
@@ -2312,7 +2283,7 @@ class SessionCatalog(
    * Returns whether it is a temporary function. If not existed, returns false.
    */
   def isTemporaryFunction(name: FunctionIdentifier): Boolean = {
-    // A temporary function is stored with database = TEMP_FUNCTION_DB
+    // A temporary function is stored with database = session namespace
     if (name.database.isEmpty) {
       val tempIdent = tempFunctionIdentifier(name.funcName)
       functionRegistry.functionExists(tempIdent) ||
@@ -2328,7 +2299,7 @@ class SessionCatalog(
    * session. If not existed, return false.
    */
   def isRegisteredFunction(name: FunctionIdentifier): Boolean = {
-    // Check if the function exists as temp (TEMP_FUNCTION_DB), builtin (3-part key), or persistent.
+    // Check if the function exists as temp, builtin (3-part key), or persistent.
     if (name.database.isEmpty) {
       val tempIdent = tempFunctionIdentifier(name.funcName)
       val builtinIdent = FunctionRegistry.builtinFunctionIdentifier(name.funcName)
@@ -2365,10 +2336,9 @@ class SessionCatalog(
   /**
    * Returns whether it is a built-in function.
    */
-  def isBuiltinFunction(name: FunctionIdentifier): Boolean = {
-    val builtinIdent = FunctionRegistry.builtinFunctionIdentifier(name.funcName)
-    FunctionRegistry.builtin.functionExists(builtinIdent) ||
-      TableFunctionRegistry.builtin.functionExists(builtinIdent)
+  def isBuiltinFunction(name: String): Boolean = {
+    FunctionRegistry.builtin.functionExists(FunctionIdentifier(name)) ||
+      TableFunctionRegistry.builtin.functionExists(FunctionIdentifier(name))
   }
 
   protected[sql] def failFunctionLookup(name: FunctionIdentifier): Nothing = {
@@ -2446,23 +2416,11 @@ class SessionCatalog(
    */
   private[sql] def identifierFromSystemNameParts(
       nameParts: Seq[String]): Option[FunctionIdentifier] = {
-    val threePart = nameParts.size match {
-      case 2 if nameParts.head.equalsIgnoreCase(CatalogManager.BUILTIN_NAMESPACE) ||
-                  nameParts.head.equalsIgnoreCase(CatalogManager.SESSION_NAMESPACE) =>
-        Some(CatalogManager.SYSTEM_CATALOG_NAME +: nameParts)
-      case 3 if nameParts.head.equalsIgnoreCase(CatalogManager.SYSTEM_CATALOG_NAME) =>
-        Some(nameParts)
-      case _ =>
-        None
-    }
-    threePart.flatMap { p =>
-      if (p(1).equalsIgnoreCase(CatalogManager.BUILTIN_NAMESPACE)) {
-        Some(FunctionRegistry.builtinFunctionIdentifier(p(2)))
-      } else if (p(1).equalsIgnoreCase(CatalogManager.SESSION_NAMESPACE)) {
-        Some(tempFunctionIdentifier(p(2)))
-      } else {
-        None
-      }
+    FunctionResolution.sessionNamespaceKind(nameParts).map {
+      case SessionCatalog.Builtin =>
+        FunctionRegistry.builtinFunctionIdentifier(nameParts.last)
+      case SessionCatalog.Temp =>
+        tempFunctionIdentifier(nameParts.last)
     }
   }
 
@@ -2737,24 +2695,14 @@ class SessionCatalog(
 
   /**
    * Lists all built-in and temporary functions matching the given pattern.
-   * Builtins are keyed as (funcName, builtin, system); temp as (funcName, session, system).
-   * The pattern is matched against the display name (simple funcName for system catalog) for
-   * backward compatibility with SHOW FUNCTIONS LIKE 'abs'.
+   * All system catalog functions (builtin and temp) are 3-part identifiers with
+   * catalog = system. The pattern is matched against funcName for backward compatibility.
    */
   private def listBuiltinAndTempFunctions(pattern: String): Seq[FunctionIdentifier] = {
     val functions = (functionRegistry.listFunction() ++ tableFunctionRegistry.listFunction())
-      .filter(f =>
-        isTempFunctionIdentifier(f) ||
-        (f.database.contains(CatalogManager.BUILTIN_NAMESPACE) &&
-          f.catalog.contains(CatalogManager.SYSTEM_CATALOG_NAME)))
-      .map(f => if (isTempFunctionIdentifier(f)) {
-        FunctionIdentifier(f.funcName)
-      } else {
-        f
-      })
-    val namesToFilter = functions.map(_.displayNameForShowFunctions)
-    val matchedNames = StringUtils.filterPattern(namesToFilter, pattern).toSet
-    functions.zip(namesToFilter).filter { case (_, name) => matchedNames.contains(name) }.map(_._1)
+      .filter(_.catalog.exists(_.equalsIgnoreCase(CatalogManager.SYSTEM_CATALOG_NAME)))
+    val matched = StringUtils.filterPattern(functions.map(_.funcName), pattern).toSet
+    functions.filter(f => matched.contains(f.funcName))
   }
 
   /**
@@ -2792,7 +2740,7 @@ class SessionCatalog(
   def listTemporaryFunctions(): Seq[FunctionIdentifier] = {
     (functionRegistry.listFunction() ++ tableFunctionRegistry.listFunction())
       .filter(isTempFunctionIdentifier)
-      // Strip the TEMP_FUNCTION_DB database qualifier
+      // Strip the session namespace database qualifier
       .map(ident => FunctionIdentifier(ident.funcName))
   }
 

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/literals.scala
@@ -39,7 +39,7 @@ import scala.util.Try
 
 import org.json4s.JsonAST._
 
-import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow, ScalaReflection}
+import org.apache.spark.sql.catalyst.{CatalystTypeConverters, FunctionIdentifier, InternalRow, ScalaReflection}
 import org.apache.spark.sql.catalyst.analysis.{FunctionRegistry, UnresolvedFunction}
 import org.apache.spark.sql.catalyst.expressions.codegen._
 import org.apache.spark.sql.catalyst.expressions.variant.VariantExpressionEvalUtils
@@ -289,7 +289,7 @@ object Literal {
         assert(u.orderingWithinGroup.isEmpty)
         assert(!u.isInternal)
         FunctionRegistry.builtin.lookupFunction(
-          FunctionRegistry.builtinFunctionIdentifier(u.nameParts.head), u.arguments)
+          FunctionIdentifier(u.nameParts.head), u.arguments)
     }
   }
 }

--- a/sql/core/src/main/scala/org/apache/spark/sql/SparkSessionExtensions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/SparkSessionExtensions.scala
@@ -29,7 +29,6 @@ import org.apache.spark.sql.catalyst.parser.ParserInterface
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.classic.Strategy
-import org.apache.spark.sql.connector.catalog.CatalogManager
 import org.apache.spark.sql.execution.{ColumnarRule, SparkPlan}
 
 /**
@@ -364,56 +363,24 @@ class SparkSessionExtensions {
 
   private[this] val injectedTableFunctions = mutable.Buffer.empty[TableFunctionDescription]
 
-  /**
-   * Normalizes an extension function identifier to a fully qualified one for registration.
-   * Accepts unqualified (1-part), fully qualified (3-part), or 2-part system names
-   * (builtin.func, session.func). It rejects other partially qualified names.
-   */
-  private def fullyQualifiedFunctionIdentifier(name: FunctionIdentifier): FunctionIdentifier = {
-    (name.catalog.isEmpty, name.database.isEmpty) match {
-      case (true, true) =>
-        // Unqualified names are registered in system.builtin.
-        FunctionRegistry.builtinFunctionIdentifier(name.funcName)
-      case (false, false) =>
-        // Fully qualified names are used as-is.
-        name
-      case (true, false) =>
-        // 2-part system names (builtin.func, session.func) only; others are invalid.
-        val db = name.database.get
-        if (!db.equalsIgnoreCase(CatalogManager.BUILTIN_NAMESPACE) &&
-            !db.equalsIgnoreCase(CatalogManager.SESSION_NAMESPACE)) {
-          throw new IllegalArgumentException(
-            s"Extension function identifier must be unqualified (funcName), fully qualified " +
-              s"(catalog.database.funcName), or 2-part system " +
-              s"(builtin.funcName / session.funcName). " +
-              s"Got 2-part with non-system database: $name")
-        }
-        FunctionIdentifier(
-          name.funcName,
-          name.database,
-          Some(CatalogManager.SYSTEM_CATALOG_NAME))
-      case (false, true) =>
-        // A 2-part identifier with catalog but no database is invalid.
-        throw new IllegalArgumentException(
-          s"Extension function identifier must be unqualified (funcName), fully qualified " +
-            s"(catalog.database.funcName), or 2-part system " +
-            s"(builtin.funcName / session.funcName). " +
-            s"Got invalid partial qualification (catalog without database): $name")
-    }
-  }
-
   private[sql] def registerFunctions(functionRegistry: FunctionRegistry) = {
     for ((name, expressionInfo, function) <- injectedFunctions) {
-      val ident = fullyQualifiedFunctionIdentifier(name)
-      functionRegistry.registerFunction(ident, expressionInfo, function)
+      // Only unqualified (1-part) names are supported — they are registered as builtins.
+      // Multi-part names were silently unreachable before and are ignored for compatibility.
+      if (name.database.isEmpty && name.catalog.isEmpty) {
+        functionRegistry.registerFunction(
+          FunctionRegistry.builtinFunctionIdentifier(name.funcName), expressionInfo, function)
+      }
     }
     functionRegistry
   }
 
   private[sql] def registerTableFunctions(tableFunctionRegistry: TableFunctionRegistry) = {
     for ((name, expressionInfo, function) <- injectedTableFunctions) {
-      val ident = fullyQualifiedFunctionIdentifier(name)
-      tableFunctionRegistry.registerFunction(ident, expressionInfo, function)
+      if (name.database.isEmpty && name.catalog.isEmpty) {
+        tableFunctionRegistry.registerFunction(
+          FunctionRegistry.builtinFunctionIdentifier(name.funcName), expressionInfo, function)
+      }
     }
     tableFunctionRegistry
   }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/command/functions.scala
@@ -158,9 +158,8 @@ case class DropFunctionCommand(
 
       // Check if temp function exists first - if it does, allow dropping it even if a builtin
       // with the same name exists (shadowing case)
-      val unqualifiedIdent = FunctionIdentifier(funcName)
-      if (!catalog.isTemporaryFunction(unqualifiedIdent) &&
-          catalog.isBuiltinFunction(unqualifiedIdent)) {
+      if (!catalog.isTemporaryFunction(FunctionIdentifier(funcName)) &&
+          catalog.isBuiltinFunction(funcName)) {
         throw QueryCompilationErrors.cannotDropBuiltinFuncError(funcName)
       }
       catalog.dropTempFunction(funcName, ifExists)


### PR DESCRIPTION
## Summary

- `normalizeFuncName` asserts fully qualified 3-part identifiers and lowercases all parts — no more resolution logic in the storage layer
- `BuiltinRegistryMixin` lets builtin/internal registries accept simple names, so callers don't need to construct 3-part keys
- Simplify `resolutionCandidates`: flat if/else, no inline qualification (`ensureThreePart` removed), persistent candidate is just the original nameParts (qualified downstream by `expandIdentifier`)
- Rename `resolveQualifiedFunction` -> `resolveFunctionCandidate` (input may not be qualified)
- Remove `namespaceToIdentifier`, `TEMP_FUNCTION_DB`; reuse `SESSION_NAMESPACE_TEMPLATE` directly
- `identifierFromSystemNameParts` reuses `FunctionResolution.sessionNamespaceKind` to centralize system namespace detection
- Simplify `listBuiltinAndTempFunctions` (single filter on system catalog, no temp-stripping)
- `isBuiltinFunction` takes `String` instead of `FunctionIdentifier`
- `SparkSessionExtensions`: only register 1-part names for backward compatibility (multi-part were silently unreachable before)

## Test plan

- Existing tests should pass — these are refactoring changes that preserve behavior
- The `normalizeFuncName` assert will catch any caller that passes non-3-part identifiers

This pull request was AI-assisted by Isaac.